### PR TITLE
Fix conflicting enum values

### DIFF
--- a/src/prism/ast.cpp
+++ b/src/prism/ast.cpp
@@ -9,7 +9,7 @@ std::shared_ptr<prism::ast::ASTNode> prism::ast::Parser::parse() {
 
 std::shared_ptr<prism::ast::ASTNode> prism::ast::Parser::parseAssign() {
     auto node = parseOr();
-    while (match(lexer::TokenType::ASSIGN)) {
+    while (match(lexer::TokenType::Assign)) {
         auto var = std::get<VariableNode>(node->node);
         auto right = parseOr();
         auto parent = std::make_shared<prism::ast::ASTNode>(AssignNode{ var, right });
@@ -20,7 +20,7 @@ std::shared_ptr<prism::ast::ASTNode> prism::ast::Parser::parseAssign() {
 
 std::shared_ptr<prism::ast::ASTNode> prism::ast::Parser::parseOr() {
     auto node = parseAnd();
-    while (match(lexer::TokenType::OR)) {
+    while (match(lexer::TokenType::Or)) {
         auto right = parseAnd();
         auto parent = std::make_shared<prism::ast::ASTNode>(OrNode{ node, right });
         node = parent;
@@ -30,7 +30,7 @@ std::shared_ptr<prism::ast::ASTNode> prism::ast::Parser::parseOr() {
 
 std::shared_ptr<prism::ast::ASTNode> prism::ast::Parser::parseAnd() {
     auto node = parseEqual();
-    while (match(lexer::TokenType::AND)) {
+    while (match(lexer::TokenType::And)) {
         auto right = parseEqual();
         auto parent = std::make_shared<prism::ast::ASTNode>(AndNode{ node, right });
         node = parent;
@@ -40,7 +40,7 @@ std::shared_ptr<prism::ast::ASTNode> prism::ast::Parser::parseAnd() {
 
 std::shared_ptr<prism::ast::ASTNode> prism::ast::Parser::parseEqual() {
     auto node = parseMul();
-    while (match(lexer::TokenType::EQUAL)) {
+    while (match(lexer::TokenType::Equal)) {
         auto right = parseMul();
         auto parent = std::make_shared<prism::ast::ASTNode>(EqualNode{ node, right });
         node = parent;
@@ -50,7 +50,7 @@ std::shared_ptr<prism::ast::ASTNode> prism::ast::Parser::parseEqual() {
 
 std::shared_ptr<prism::ast::ASTNode> prism::ast::Parser::parseMul() {
     auto node = parseDiv();
-    while (match(lexer::TokenType::MUL)) {
+    while (match(lexer::TokenType::Mul)) {
         auto right = parseDiv();
         auto parent = std::make_shared<prism::ast::ASTNode>(MulNode{ node, right });
         node = parent;
@@ -60,7 +60,7 @@ std::shared_ptr<prism::ast::ASTNode> prism::ast::Parser::parseMul() {
 
 std::shared_ptr<prism::ast::ASTNode> prism::ast::Parser::parseDiv() {
     auto node = parseAdd();
-    while (match(lexer::TokenType::DIV)) {
+    while (match(lexer::TokenType::Div)) {
         auto right = parseAdd();
         auto parent = std::make_shared<prism::ast::ASTNode>(DivNode{ node, right });
         node = parent;
@@ -70,7 +70,7 @@ std::shared_ptr<prism::ast::ASTNode> prism::ast::Parser::parseDiv() {
 
 std::shared_ptr<prism::ast::ASTNode> prism::ast::Parser::parseAdd() {
     auto node = parseSub();
-    while (match(lexer::TokenType::ADD)) {
+    while (match(lexer::TokenType::Add)) {
         auto right = parseSub();
         auto parent = std::make_shared<prism::ast::ASTNode>(AddNode{ node, right });
         node = parent;
@@ -80,7 +80,7 @@ std::shared_ptr<prism::ast::ASTNode> prism::ast::Parser::parseAdd() {
 
 std::shared_ptr<prism::ast::ASTNode> prism::ast::Parser::parseSub() {
     auto node = parseIn();
-    while (match(lexer::TokenType::SUB)) {
+    while (match(lexer::TokenType::Sub)) {
         auto right = parseIn();
         auto parent = std::make_shared<prism::ast::ASTNode>(SubNode{ node, right });
         node = parent;
@@ -90,7 +90,7 @@ std::shared_ptr<prism::ast::ASTNode> prism::ast::Parser::parseSub() {
 
 std::shared_ptr<prism::ast::ASTNode> prism::ast::Parser::parseIn() {
     auto node = parseRange();
-    while (match(lexer::TokenType::IN)) {
+    while (match(lexer::TokenType::In)) {
         auto right = parseRange();
         auto parent = std::make_shared<prism::ast::ASTNode>(InNode{ node, right });
         node = parent;
@@ -100,7 +100,7 @@ std::shared_ptr<prism::ast::ASTNode> prism::ast::Parser::parseIn() {
 
 std::shared_ptr<prism::ast::ASTNode> prism::ast::Parser::parseRange() {
     auto node = parsePrimary();
-    while (match(lexer::TokenType::RANGE)) {
+    while (match(lexer::TokenType::Range)) {
         auto right = parsePrimary();
         auto parent = std::make_shared<prism::ast::ASTNode>(RangeNode{ node, right });
         node = parent;
@@ -109,42 +109,42 @@ std::shared_ptr<prism::ast::ASTNode> prism::ast::Parser::parseRange() {
 }
 // Parses parentheses or variables
 std::shared_ptr<prism::ast::ASTNode> prism::ast::Parser::parsePrimary() {
-    if (match(lexer::TokenType::LPAREN)) {
+    if (match(lexer::TokenType::LParen)) {
         auto node = parse();
-        expect(lexer::TokenType::RPAREN); // Ensure closing ')'
+        expect(lexer::TokenType::RParen); // Ensure closing ')'
         return node;
     }
 
-    if (match(lexer::TokenType::INTEGER)) {
+    if (match(lexer::TokenType::Integer)) {
         return std::make_shared<ASTNode>(IntegerNode{ std::stoi(previous().value) });
     }
 
-    if (match(lexer::TokenType::FLOAT)) {
+    if (match(lexer::TokenType::Float)) {
         return std::make_shared<ASTNode>(FloatNode{ std::stof(previous().value) });
     }
 
-    if (match(lexer::TokenType::TRUE)) {
+    if (match(lexer::TokenType::True)) {
         return std::make_shared<ASTNode>(IntegerNode{ 1 });
     }
 
-    if (match(lexer::TokenType::FALSE)) {
+    if (match(lexer::TokenType::False)) {
         return std::make_shared<ASTNode>(IntegerNode{ 0 });
     }
 
-    if (match(lexer::TokenType::IF)) {
+    if (match(lexer::TokenType::If)) {
         auto condition = parse();
-        expect(lexer::TokenType::THEN); // Ensure 'then' keyword
+        expect(lexer::TokenType::Then); // Ensure 'then' keyword
         auto body = parse();
         std::shared_ptr<std::vector<std::shared_ptr<ElseIfNode>>> elseIfs =
             std::make_shared<std::vector<std::shared_ptr<ElseIfNode>>>();
-        while (match(lexer::TokenType::ELSEIF)) {
+        while (match(lexer::TokenType::Elseif)) {
             auto elseIfCondition = parse();
-            expect(lexer::TokenType::THEN); // Ensure 'then' keyword
+            expect(lexer::TokenType::Then); // Ensure 'then' keyword
             auto elseIfBody = parse();
             elseIfs->push_back(std::make_shared<ElseIfNode>(ElseIfNode{ elseIfCondition, elseIfBody }));
         }
 
-        if (match(lexer::TokenType::ELSE)) {
+        if (match(lexer::TokenType::Else)) {
             auto elseBody = parse();
             return std::make_shared<ASTNode>(IfNode{ condition, body, elseIfs, elseBody });
         }
@@ -152,41 +152,41 @@ std::shared_ptr<prism::ast::ASTNode> prism::ast::Parser::parsePrimary() {
         throw std::runtime_error("Unexpected token");
     }
 
-    if (match(lexer::TokenType::QUOTE)) {
+    if (match(lexer::TokenType::Quote)) {
         return std::make_shared<ASTNode>(QuoteNode{ previous().value });
     }
 
-    if (match(lexer::TokenType::NOT)) {
+    if (match(lexer::TokenType::Not)) {
         return std::make_shared<ASTNode>(NotNode{ parsePrimary() });
     }
 
-    if (match(lexer::TokenType::IDENTIFIER)) {
+    if (match(lexer::TokenType::Inentifier)) {
         std::string varName = previous().value;
         std::shared_ptr<VariableNode> variable = std::make_shared<VariableNode>(VariableNode{ varName });
 
-        if (match(lexer::TokenType::LBRACKET)) {
+        if (match(lexer::TokenType::LBracket)) {
             auto arrayIndices = std::make_shared<std::vector<std::shared_ptr<ASTNode>>>();
             // Loop to handle multiple array accesses (e.g., var[0][1][2])
             do {
                 auto indexNode = parsePrimary();    // Parse the index (e.g., 0, 1)
-                expect(lexer::TokenType::RBRACKET); // Expect closing bracket
+                expect(lexer::TokenType::RBracket); // Expect closing bracket
 
                 arrayIndices->push_back(indexNode);
-            } while (match(lexer::TokenType::LBRACKET));
+            } while (match(lexer::TokenType::LBracket));
 
             return std::make_shared<ASTNode>(ArrayAccessNode{ variable, arrayIndices });
         }
 
-        if (match(lexer::TokenType::LPAREN)) {
+        if (match(lexer::TokenType::LParen)) {
             auto args = std::make_shared<std::vector<std::shared_ptr<ASTNode>>>();
             do {
-                if (isNext(lexer::TokenType::RPAREN)) {
+                if (isNext(lexer::TokenType::RParen)) {
                     break;
                 }
                 auto arg = parse();
                 args->push_back(arg);
-            } while (match(lexer::TokenType::COMMA));
-            expect(lexer::TokenType::RPAREN);
+            } while (match(lexer::TokenType::Comma));
+            expect(lexer::TokenType::RParen);
             return std::make_shared<ASTNode>(FunctionCallNode{ variable, args });
         }
         return std::make_shared<ASTNode>(*variable);

--- a/src/prism/ast.cpp
+++ b/src/prism/ast.cpp
@@ -160,7 +160,7 @@ std::shared_ptr<prism::ast::ASTNode> prism::ast::Parser::parsePrimary() {
         return std::make_shared<ASTNode>(NotNode{ parsePrimary() });
     }
 
-    if (match(lexer::TokenType::Inentifier)) {
+    if (match(lexer::TokenType::Identifier)) {
         std::string varName = previous().value;
         std::shared_ptr<VariableNode> variable = std::make_shared<VariableNode>(VariableNode{ varName });
 

--- a/src/prism/lexer.cpp
+++ b/src/prism/lexer.cpp
@@ -16,7 +16,7 @@ std::vector<prism::lexer::Token> prism::lexer::Lexer::tokenize() {
         char current = input[pos];
         if (inString) {
             if (current == '"') {
-                tokens.emplace_back(TokenType::QUOTE, currentString);
+                tokens.emplace_back(TokenType::Quote, currentString);
                 currentString.clear();
                 inString = false;
             } else {
@@ -31,7 +31,7 @@ std::vector<prism::lexer::Token> prism::lexer::Lexer::tokenize() {
         }
 
         if (isKeyWord(input, pos) && std::isalpha(current) || current == '_') {
-            tokens.emplace_back(TokenType::IDENTIFIER, parseIdentifier());
+            tokens.emplace_back(TokenType::Inentifier, parseIdentifier());
             continue;
         }
 
@@ -39,37 +39,37 @@ std::vector<prism::lexer::Token> prism::lexer::Lexer::tokenize() {
             bool hasDecimal = false;
             if (input.substr(pos + 1, 2) == "..") {
                 auto result = parseNumber(nullptr);
-                tokens.emplace_back(TokenType::INTEGER, result);
+                tokens.emplace_back(TokenType::Integer, result);
             } else {
                 auto result = parseNumber(&hasDecimal);
-                tokens.emplace_back(hasDecimal ? TokenType::FLOAT : TokenType::INTEGER, result);
+                tokens.emplace_back(hasDecimal ? TokenType::Float : TokenType::Integer, result);
             }
             continue;
         }
 
         switch (current) {
             case '(':
-                tokens.emplace_back(TokenType::LPAREN, "(");
+                tokens.emplace_back(TokenType::LParen, "(");
                 pos++;
                 break;
             case ')':
-                tokens.emplace_back(TokenType::RPAREN, ")");
+                tokens.emplace_back(TokenType::RParen, ")");
                 pos++;
                 break;
             case ',':
-                tokens.emplace_back(TokenType::COMMA, ",");
+                tokens.emplace_back(TokenType::Comma, ",");
                 pos++;
                 break;
             case '[':
-                tokens.emplace_back(TokenType::LBRACKET, "[");
+                tokens.emplace_back(TokenType::LBracket, "[");
                 pos++;
                 break;
             case ']':
-                tokens.emplace_back(TokenType::RBRACKET, "]");
+                tokens.emplace_back(TokenType::RBracket, "]");
                 pos++;
                 break;
             case '!':
-                tokens.emplace_back(TokenType::NOT, "!");
+                tokens.emplace_back(TokenType::Not, "!");
                 pos++;
                 break;
             case '"':
@@ -78,89 +78,89 @@ std::vector<prism::lexer::Token> prism::lexer::Lexer::tokenize() {
                 break;
             case '|':
                 if (peek() == '|') {
-                    tokens.emplace_back(TokenType::OR, "||");
+                    tokens.emplace_back(TokenType::Or, "||");
                     pos += 2;
                 }
                 break;
             case '&':
                 if (peek() == '&') {
-                    tokens.emplace_back(TokenType::AND, "&&");
+                    tokens.emplace_back(TokenType::And, "&&");
                     pos += 2;
                 }
                 break;
             case '=':
                 if (peek() == '=') {
-                    tokens.emplace_back(TokenType::EQUAL, "==");
+                    tokens.emplace_back(TokenType::Equal, "==");
                     pos += 2;
                 } else {
-                    tokens.emplace_back(TokenType::ASSIGN, "=");
+                    tokens.emplace_back(TokenType::Assign, "=");
                     pos++;
                 }
                 break;
             case '+':
-                tokens.emplace_back(TokenType::ADD, "+");
+                tokens.emplace_back(TokenType::Add, "+");
                 pos++;
                 break;
             case '-':
-                tokens.emplace_back(TokenType::SUB, "-");
+                tokens.emplace_back(TokenType::Sub, "-");
                 pos++;
                 break;
             case '*':
-                tokens.emplace_back(TokenType::MUL, "*");
+                tokens.emplace_back(TokenType::Mul, "*");
                 pos++;
                 break;
             case '/':
-                tokens.emplace_back(TokenType::DIV, "/");
+                tokens.emplace_back(TokenType::Div, "/");
                 pos++;
                 break;
             case 'i':
                 if (peek() == 'n' && input.substr(pos, 7) != "include") {
-                    tokens.emplace_back(TokenType::IN, "in");
+                    tokens.emplace_back(TokenType::In, "in");
                     pos += 2;
                 } else if (peek() == 'f') {
-                    tokens.emplace_back(TokenType::IF, "if");
+                    tokens.emplace_back(TokenType::If, "if");
                     pos += 2;
                 } else {
-                    tokens.emplace_back(TokenType::IDENTIFIER, parseIdentifier());
+                    tokens.emplace_back(TokenType::Inentifier, parseIdentifier());
                 }
                 break;
             case 'e':
                 if (peek() == 'l') {
                     if (input.substr(pos, 4) == "else") {
-                        tokens.emplace_back(TokenType::ELSE, "else");
+                        tokens.emplace_back(TokenType::Else, "else");
                         pos += 4;
                     } else if (input.substr(pos, 6) == "elseif") {
-                        tokens.emplace_back(TokenType::ELSEIF, "elseif");
+                        tokens.emplace_back(TokenType::Elseif, "elseif");
                         pos += 6;
                     } else {
-                        tokens.emplace_back(TokenType::IDENTIFIER, parseIdentifier());
+                        tokens.emplace_back(TokenType::Inentifier, parseIdentifier());
                     }
                 } else {
-                    tokens.emplace_back(TokenType::IDENTIFIER, parseIdentifier());
+                    tokens.emplace_back(TokenType::Inentifier, parseIdentifier());
                 }
                 break;
             case 't':
                 if (input.substr(pos, 4) == "then") {
-                    tokens.emplace_back(TokenType::THEN, "then");
+                    tokens.emplace_back(TokenType::Then, "then");
                     pos += 4;
                 } else if (input.substr(pos, 4) == "true") {
-                    tokens.emplace_back(TokenType::TRUE, "true");
+                    tokens.emplace_back(TokenType::True, "true");
                     pos += 4;
                 } else {
-                    tokens.emplace_back(TokenType::IDENTIFIER, parseIdentifier());
+                    tokens.emplace_back(TokenType::Inentifier, parseIdentifier());
                 }
                 break;
             case 'f':
                 if (input.substr(pos, 5) == "false") {
-                    tokens.emplace_back(TokenType::FALSE, "false");
+                    tokens.emplace_back(TokenType::False, "false");
                     pos += 5;
                 } else {
-                    tokens.emplace_back(TokenType::IDENTIFIER, parseIdentifier());
+                    tokens.emplace_back(TokenType::Inentifier, parseIdentifier());
                 }
                 break;
             case '.':
                 if (peek() == '.') {
-                    tokens.emplace_back(TokenType::RANGE, "..");
+                    tokens.emplace_back(TokenType::Range, "..");
                     pos += 2;
                 } else {
                     throw prism::SyntaxError("Unexpected character " + std::string(1, current));
@@ -174,7 +174,7 @@ std::vector<prism::lexer::Token> prism::lexer::Lexer::tokenize() {
         }
     }
 
-    tokens.emplace_back(TokenType::END_OF_INPUT);
+    tokens.emplace_back(TokenType::EndOfinput);
     return tokens;
 }
 

--- a/src/prism/lexer.cpp
+++ b/src/prism/lexer.cpp
@@ -31,7 +31,7 @@ std::vector<prism::lexer::Token> prism::lexer::Lexer::tokenize() {
         }
 
         if (isKeyWord(input, pos) && std::isalpha(current) || current == '_') {
-            tokens.emplace_back(TokenType::Inentifier, parseIdentifier());
+            tokens.emplace_back(TokenType::Identifier, parseIdentifier());
             continue;
         }
 
@@ -121,7 +121,7 @@ std::vector<prism::lexer::Token> prism::lexer::Lexer::tokenize() {
                     tokens.emplace_back(TokenType::If, "if");
                     pos += 2;
                 } else {
-                    tokens.emplace_back(TokenType::Inentifier, parseIdentifier());
+                    tokens.emplace_back(TokenType::Identifier, parseIdentifier());
                 }
                 break;
             case 'e':
@@ -133,10 +133,10 @@ std::vector<prism::lexer::Token> prism::lexer::Lexer::tokenize() {
                         tokens.emplace_back(TokenType::Elseif, "elseif");
                         pos += 6;
                     } else {
-                        tokens.emplace_back(TokenType::Inentifier, parseIdentifier());
+                        tokens.emplace_back(TokenType::Identifier, parseIdentifier());
                     }
                 } else {
-                    tokens.emplace_back(TokenType::Inentifier, parseIdentifier());
+                    tokens.emplace_back(TokenType::Identifier, parseIdentifier());
                 }
                 break;
             case 't':
@@ -147,7 +147,7 @@ std::vector<prism::lexer::Token> prism::lexer::Lexer::tokenize() {
                     tokens.emplace_back(TokenType::True, "true");
                     pos += 4;
                 } else {
-                    tokens.emplace_back(TokenType::Inentifier, parseIdentifier());
+                    tokens.emplace_back(TokenType::Identifier, parseIdentifier());
                 }
                 break;
             case 'f':
@@ -155,7 +155,7 @@ std::vector<prism::lexer::Token> prism::lexer::Lexer::tokenize() {
                     tokens.emplace_back(TokenType::False, "false");
                     pos += 5;
                 } else {
-                    tokens.emplace_back(TokenType::Inentifier, parseIdentifier());
+                    tokens.emplace_back(TokenType::Identifier, parseIdentifier());
                 }
                 break;
             case '.':

--- a/src/prism/lexer.h
+++ b/src/prism/lexer.h
@@ -6,33 +6,33 @@
 
 namespace prism::lexer {
 enum class TokenType {
-    IDENTIFIER,  // Variable names
-    INTEGER,     // Number
-    FLOAT,       // Float
-    LPAREN,      // '('
-    RPAREN,      // ')'
-    LBRACKET,    // '['
-    RBRACKET,    // ']'
-    COMMA,       // ','
-    OR,          // '||'
-    AND,         // '&&'
-    EQUAL,       // '=='
-    ASSIGN,      // '='
-    NOT,         // '!'
-    ADD,         // '+'
-    SUB,         // '-'
-    MUL,         // '*'
-    DIV,         // '/'
-    IN,          // in
-    QUOTE,       // '"'
-    IF,          // if
-    THEN,        // then
-    ELSE,        // else
-    ELSEIF,      // elseif
-    RANGE,       // ..
-    TRUE,        // true
-    FALSE,       // false
-    END_OF_INPUT // End of script
+    Inentifier,  // Variable names
+    Integer,     // Number
+    Float,       // Float
+    LParen,      // '('
+    RParen,      // ')'
+    LBracket,    // '['
+    RBracket,    // ']'
+    Comma,       // ','
+    Or,          // '||'
+    And,         // '&&'
+    Equal,       // '=='
+    Assign,      // '='
+    Not,         // '!'
+    Add,         // '+'
+    Sub,         // '-'
+    Mul,         // '*'
+    Div,         // '/'
+    In,          // in
+    Quote,       // '"'
+    If,          // if
+    Then,        // then
+    Else,        // else
+    Elseif,      // elseif
+    Range,       // ..
+    True,        // true
+    False,       // false
+    EndOfinput // End of script
 };
 
 struct Token {

--- a/src/prism/lexer.h
+++ b/src/prism/lexer.h
@@ -6,7 +6,7 @@
 
 namespace prism::lexer {
 enum class TokenType {
-    Inentifier,  // Variable names
+    Identifier,  // Variable names
     Integer,     // Number
     Float,       // Float
     LParen,      // '('


### PR DESCRIPTION
The `TokenType` enum contains several values that are used by Windows headers. These include `IN`, `TRUE` and `FALSE`. This changes them to not use all upper case.