### PR TITLE
fix: revert embedded spdlog FetchContent fallback

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        run: sudo apt-get install cmake ninja-build libbz2-dev
+        run: sudo apt-get install cmake ninja-build libbz2-dev libspdlog-dev
       - name: Build
         run: |
           cmake -H. -Bbuild-cmake -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.config }} -DPRISM_STANDALONE=${{ matrix.standalone }} -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain/${{ matrix.toolchain }}.cmake

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        run: brew install cmake ninja xcodes
+        run: brew install cmake ninja xcodes spdlog
       - name: Download llvm
         if: ${{ matrix.toolchain == 'macos-clang-llvm' }}
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,10 +25,12 @@ jobs:
             standalone: OFF
     steps:
       - uses: actions/checkout@v4
+      - name: Install spdlog via vcpkg
+        run: vcpkg install spdlog:${{ matrix.arch == 'x64' && 'x64-windows' || 'x86-windows' }}
       - name: Build Visual Studio
         if: ${{ matrix.generate == 'Visual Studio 17 2022' }}
         run: |
-          cmake -S . -B "build/${{ matrix.arch }}" -G "${{ matrix.generate }}" -DCMAKE_TOOLCHAIN_FILE="cmake/toolchain/${{ matrix.toolchain }}.cmake" -DCMAKE_GENERATOR_PLATFORM=${{ matrix.arch }} -DCMAKE_BUILD_TYPE:STRING=${{ matrix.config }} -DPRISM_STANDALONE=${{ matrix.standalone }}
+          cmake -S . -B "build/${{ matrix.arch }}" -G "${{ matrix.generate }}" -DCMAKE_TOOLCHAIN_FILE="C:/vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_CHAINLOAD_TOOLCHAIN_FILE="${{ github.workspace }}/cmake/toolchain/${{ matrix.toolchain }}.cmake" -DCMAKE_GENERATOR_PLATFORM=${{ matrix.arch }} -DCMAKE_BUILD_TYPE:STRING=${{ matrix.config }} -DPRISM_STANDALONE=${{ matrix.standalone }}
           cmake --build ./build/${{ matrix.arch }}
       - name: Setup Variables
         if: ${{ matrix.generate == 'Ninja' }}
@@ -38,7 +40,7 @@ jobs:
       - name: Build Ninja
         if: ${{ matrix.generate == 'Ninja' }}
         run: |
-          cmake -S . -B "build/${{ matrix.arch }}" -G "${{ matrix.generate }}" -DCMAKE_TOOLCHAIN_FILE="cmake/toolchain/${{ matrix.toolchain }}.cmake" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.config }} -DPRISM_STANDALONE=${{ matrix.standalone }}
+          cmake -S . -B "build/${{ matrix.arch }}" -G "${{ matrix.generate }}" -DCMAKE_TOOLCHAIN_FILE="C:/vcpkg/scripts/buildsystems/vcpkg.cmake" -DVCPKG_CHAINLOAD_TOOLCHAIN_FILE="${{ github.workspace }}/cmake/toolchain/${{ matrix.toolchain }}.cmake" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.config }} -DPRISM_STANDALONE=${{ matrix.standalone }}
           cmake --build ./build/${{ matrix.arch }}
       - name: Publish packaged artifacts
         if: ${{ matrix.config == 'Release' && matrix.generate == 'Visual Studio 17 2022' && matrix.standalone == 'ON' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,14 +123,6 @@ if(PRISM_STANDALONE)
 	target_link_libraries(${PROJECT_NAME} PRIVATE spdlog)
 else()
 	find_package(spdlog QUIET)
-    if (NOT spdlog_FOUND)
-        FetchContent_Declare(
-            spdlog
-            GIT_REPOSITORY https://github.com/gabime/spdlog.git
-            GIT_TAG 7e635fca68d014934b4af8a1cf874f63989352b7
-        )
-        FetchContent_MakeAvailable(spdlog)
-    endif()
     target_link_libraries(${PROJECT_NAME} PUBLIC spdlog::spdlog)
 endif()
 


### PR DESCRIPTION
## Summary

- Removes the `FetchContent` fallback added in `50eed07` from the embedded (non-standalone) spdlog path
- Reverts to `find_package(spdlog QUIET)` only, trusting the parent project to provide spdlog
- Adds `libspdlog-dev` / `spdlog` (brew) / vcpkg spdlog to CI so the standalone builds and embedded CI builds resolve it

## Why

When prism is embedded in a parent project that already provides spdlog via FetchContent (e.g. libultraship), the `FetchContent_Declare` added in `50eed07` conflicts with the parent's existing spdlog declaration. On Android and iOS this causes the build to fail because the resulting target isn't `spdlog::spdlog`.

You can see the failure in this draft PR to libultraship which updates prism from `bbcbc7e` to `e313fa8` (the current tip before this fix): https://github.com/Kenix3/libultraship/pull/1029

The same PR passes CI when pointed at this branch instead.