### PR TITLE
fix: guard ctest registration behind PRISM_STANDALONE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,7 @@ if(NOT PRISM_STANDALONE)
     target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
 endif()
 
-enable_testing()
-
-add_test(NAME prism COMMAND prism ../examples/script.opengl.fs)
+if(PRISM_STANDALONE)
+    enable_testing()
+    add_test(NAME prism COMMAND prism ../examples/script.opengl.fs)
+endif()


### PR DESCRIPTION
## Summary

Wraps `enable_testing()` and `add_test()` in `if(PRISM_STANDALONE)` so they are not registered when prism is consumed as a subdirectory by a parent project.

## Why

When a parent project (e.g. libultraship) uses `FetchContent` to pull in prism, the unconditional `enable_testing()` / `add_test()` calls cause a `prism` test to appear in the parent's CTest run. This test always fails in that context because the `prism` executable and example scripts aren't present in the parent's build tree.

This is safe to guard behind `PRISM_STANDALONE` because the test invokes the `prism` executable directly (`COMMAND prism ../examples/script.opengl.fs`) — that binary only exists when built standalone anyway, so the test was already broken in the non-standalone case regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)