### PR TITLE
cmake_minimum_required(3.14)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.14)
 project(prism)
 include(FetchContent)
 


### PR DESCRIPTION
3.14 was already required do to use of `FetchContent_MakeAvailable`

Silences:
```
CMake Warning (deprecated) at CMakeLists.txt:2 (cmake_minimum_required):
Compatibility with CMake < 3.10 will be removed from a future version of
CMake.

Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
to tell CMake that the project requires at least <min> but has been updated
to work with policies introduced by <max> or earlier.
```